### PR TITLE
add a synchronous implementation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ var getTree = function(from, options, callback) {
     stack.done(function() {
         callback(errors, Object.keys(results).sort());
     });
-    
+
 };
 
 var filterTree = function (tree, options, callback) {
@@ -93,7 +93,7 @@ var createDirs = function(dirs, to, options, callback) {
     dirs.forEach(function(dir) {
         var stat = options.stats[dir],
             to = options.toHash[dir];
-        
+
         if (to && typeof to === 'string') {
             fs.stat(to, stack.add(function(err, s) {
                 if (s && s.isDirectory()) {
@@ -262,6 +262,9 @@ var cpr = function(from, to, opts, callback) {
         }
     });
 };
+
+// expose the synchronous version
+cpr.sync = require('./sync');
 
 //Preserve backward compatibility
 cpr.cpr = cpr;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2012, Yahoo! Inc. All rights reserved.
+Code licensed under the BSD License:
+http://yuilibrary.com/license/
+*/
+var fs = require('graceful-fs');
+var path = require('path');
+var mkdirp = require('mkdirp').sync;
+var cp = require('cp').sync;
+
+// copy a symlink
+function symlinkSync(src, dest) {
+    var link = fs.readlinkSync(src);
+    fs.symlinkSync(link, dest);
+}
+
+// copy the contents of a directory
+function dirSync(src, dest) {
+    mkdirp(dest);
+    fs.readdirSync(src).forEach(function (name) {
+        sync(path.join(src, name), path.join(dest, name));
+    });
+}
+
+// synchronous implementation
+var sync = module.exports = function (src, dest) {
+    var stat = fs.lstatSync(src);
+
+    // just copy files
+    if (stat.isFile()) {
+        return cp(src, dest);
+    }
+
+    // read the sym link and create a new one
+    if (stat.isSymbolicLink()) {
+        return symlinkSync(src, dest);
+    }
+
+    // note a file or a symlink?  probably a directory,
+    // so we'll copy its contents
+    dirSync(src, dest);
+};

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -8,6 +8,8 @@ var path = require('path');
 var mkdirp = require('mkdirp').sync;
 var cp = require('cp').sync;
 
+var sync;
+
 // copy a symlink
 function symlinkSync(src, dest) {
     var link = fs.readlinkSync(src);
@@ -23,7 +25,7 @@ function dirSync(src, dest) {
 }
 
 // synchronous implementation
-var sync = module.exports = function (src, dest) {
+sync = module.exports = function (src, dest) {
     var stat = fs.lstatSync(src);
 
     // just copy files

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
     "dependencies": {
         "graceful-fs": "~1.2.0",
         "rimraf": "~2.0.2",
-        "mkdirp": "~0.3.4"
+        "mkdirp": "~0.3.4",
+        "cp": "~0.1.1"
     },
     "main": "./lib/index.js",
     "devDependencies": {
         "jshint": "~0.9.1",
         "yui-lint": "~0.1.0",
         "istanbul": "~0.1.8",
-        "vows": "*" 
+        "vows": "*"
     },
     "contributors": [
         { "name": "Elijah Insua", "email": "tmpvar@gmail.com" }

--- a/tests/full.js
+++ b/tests/full.js
@@ -20,6 +20,9 @@ var tests = {
         'and should export cpr method too': function (topic) {
             assert.isFunction(topic.cpr);
         },
+        'and should export a synchronous implementation': function (topic) {
+            assert.isFunction(topic.sync);
+        },
         'and should copy node_modules': {
             topic: function() {
                 var out = path.join(to, '0'),
@@ -241,6 +244,31 @@ var tests = {
             assert.isUndefined(topic.status);
             assert.ok(topic.err);
             assert.equal('From should be a directory', topic.err);
+        }
+    },
+    'cpr.sync should synchronously copy node_modules': {
+        topic: function () {
+            var out = path.join(to, 'sync-0');
+
+            try {
+                cpr.sync(from, out);
+            } catch (err) {
+                return this.callback(err);
+            }
+
+            this.callback(null, out);
+        },
+        'should not error': function (err, dir) {
+            assert.ifError(err);
+        },
+        'should create the node_modules directory': function (err, dir) {
+            assert.ok(fs.existsSync(dir));
+        },
+        'should create equal directories': function (err, dir) {
+            var expected = fs.readdirSync(from);
+            var actual = fs.readdirSync(dir);
+
+            assert.deepEqual(actual, expected);
         }
     }
 };


### PR DESCRIPTION
for some reason, with all of the `cp -r` style modules out there, none of them have a sync version.  i've added a simple synchronous implementation which allows for:

``` js
var cpr = require('cpr');

cpr.sync('/some/existing/dir', '/this/doesnt/exist/yet')
```

please note: i have not added support for any of your "options".  just a synchronous `cp -r`.
