### PR TITLE
Standardise errors to be more node-like, fixes #5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ cpr('/path/from', '/path/to', {
     deleteFirst: true, //Delete "to" before
     overwrite: true, //If the file exists, overwrite it
     confirm: true //After the copy, stat all the copied files to make sure they are there
-}, function(errs, files) {
-    //errs - Array of errors that occurred
+}, function(err, files) {
+    //err - The error if any (err.list might be available with an array of errors for more detailed information)
     //files - List of files that we copied
 });
 
-cpr('/path/from', '/path/to', function(errs, files) {
-    //errs - Array of errors that occurred
+cpr('/path/from', '/path/to', function(err, files) {
+    //err - The error if any (err.list might be available with an array of errors for more detailed information)
     //files - List of files that we copied
 });
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,6 @@ var getTree = function(from, options, callback) {
     stack.done(function() {
         callback(errors, Object.keys(results).sort());
     });
-    
 };
 
 var filterTree = function (tree, options, callback) {
@@ -93,7 +92,7 @@ var createDirs = function(dirs, to, options, callback) {
     dirs.forEach(function(dir) {
         var stat = options.stats[dir],
             to = options.toHash[dir];
-        
+
         if (to && typeof to === 'string') {
             fs.stat(to, stack.add(function(err, s) {
                 if (s && s.isDirectory()) {
@@ -223,7 +222,7 @@ var cpr = function(from, to, opts, callback) {
             filterTree(tree, options, function(err, t) {
                 splitTree(t, options, function(dirs, files) {
                     if (!dirs.length && !files.length) {
-                        return callback('no files to copy');
+                        return callback(new Error('No files to copy'));
                     }
                     createDirs(dirs, to, options, function() {
                         createFiles(files, to, options, function() {
@@ -233,8 +232,11 @@ var cpr = function(from, to, opts, callback) {
                             });
                             if (options.confirm) {
                                 confirm(out, options, callback);
+                            } else if (!options.errors.length) {
+                                callback(null, out.sort());
                             } else {
-                                err = options.errors.length ? options.errors : null;
+                                err = new Error('Unable to copy directory' + (out.length ? ' entirely' : ''));
+                                err.list = options.errors;
                                 callback(err, out.sort());
                             }
                         });
@@ -246,7 +248,7 @@ var cpr = function(from, to, opts, callback) {
 
     fs.stat(options.from, function(err, stat) {
         if (err) {
-            return callback('From should be a directory');
+            return callback(new Error('From should be a directory'));
         }
         if (stat && stat.isDirectory()) {
             if (options.deleteFirst) {
@@ -258,7 +260,7 @@ var cpr = function(from, to, opts, callback) {
 
             }
         } else {
-            callback('From should be a directory');
+            callback(new Error('From should be a directory'));
         }
     });
 };

--- a/tests/full.js
+++ b/tests/full.js
@@ -76,11 +76,11 @@ var tests = {
                 });
             },
             'does not have ./out/1': function(topic) {
-                assert.ok(topic.stat); //Should be an error
+                assert.ok(topic.stat); // Should be an error
             },
             'and threw an error': function(topic) {
-                assert.ok(topic.err); //Should be an error
-                assert.equal(topic.err, 'no files to copy');
+                assert(topic.err instanceof Error); // Should be an error
+                assert.equal(topic.err.message, 'No files to copy');
             }
         },
         'and should not copy yui-lint from regex': {
@@ -223,8 +223,8 @@ var tests = {
         },
         "should return an error in the callback": function(topic) {
             assert.isUndefined(topic.status);
-            assert.ok(topic.err);
-            assert.equal('From should be a directory', topic.err);
+            assert(topic.err instanceof Error);
+            assert.equal('From should be a directory', topic.err.message);
         }
     },
     "should fail on from not a dir": {
@@ -239,8 +239,8 @@ var tests = {
         },
         "should return an error in the callback": function(topic) {
             assert.isUndefined(topic.status);
-            assert.ok(topic.err);
-            assert.equal('From should be a directory', topic.err);
+            assert(topic.err instanceof Error);
+            assert.equal('From should be a directory', topic.err.message);
         }
     }
 };


### PR DESCRIPTION
I ended up with the following callback logic for all the cases, which I think is more node-like and intuitive.

``` js
cpr('from', 'to', function (err, files) {
      // Standard node-like error instance
      if (err) {
         console.log(err.message);
         // err.list is the original errors that were caught when copying
         // Note that this is for advanced usage
         err.list && err.list.forEach(function (err) { console.log('>', err.message); });
     }
});
```

If you guys don't agree, I can always remake to do what I original said.
