### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,7 @@
   "bugs": {
     "url": "http://github.com/davglass/cpr/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/davglass/cpr/blob/master/LICENSE"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "http://github.com/davglass/cpr.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/