### PR TITLE
graceful-fs@4.1.2, rimraf@2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "author": "Dav Glass <davglass@gmail.com>",
   "version": "0.4.1",
   "dependencies": {
-    "graceful-fs": "~3.0.5",
+    "graceful-fs": "~4.1.2",
     "mkdirp": "~0.5.0",
-    "rimraf": "~2.2.8"
+    "rimraf": "~2.4.3"
   },
   "main": "./lib/index.js",
   "devDependencies": {


### PR DESCRIPTION
Updated the relevant deps. The newest graceful-fs doesn't rely on monkey-patching anymore. Tests look to be passing just fine. Ran them on Windows and OS X.