### PR TITLE
Add basic CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,10 @@ If you give it a `RegExp`, it will use that to `test` the filename as they are b
 If you give it a `function`, it will use that with `Array.filter` on the list of files.
 
 
+CLI
+---
+
+`cpr` can also be used from the command line which is useful for cross platform support.
+
+
 ![cpr](../master/cpr.jpg?raw=true)

--- a/bin/cpr
+++ b/bin/cpr
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+var cpr = require('../lib')
+
+var help = false;
+var dashdash = false;
+
+var args = process.argv.slice(2).filter(function (arg) {
+  if (dashdash) {
+    return !!arg;
+  } else if (arg === '--') {
+    dashdash = true;
+  } else if (arg.match(/^(-+|\/)(h(elp)?|\?)$/)) {
+    help = true;
+  } else {
+    return !!arg;
+  }
+});
+
+if (help || args.length != 2) {
+  // If they didn't ask for help, then this is not a "success"
+  var log = help ? console.log : console.error;
+  log('Usage: cpr <source_dir> <destination_dir>');
+  log('');
+  log('  Copies files from one directory to another');
+  log('');
+  log('Options:');
+  log('');
+  log('  -h, --help            Display this usage info');
+  process.exit(help ? 0 : 1);
+} else {
+  cpr(args[0], args[1], function (err) {
+    if (err) {
+      console.error("Error: " + err.message);
+      process.exit(1);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rimraf": "~2.4.3"
   },
   "main": "./lib/index.js",
+  "bin": "./bin/cpr",
   "devDependencies": {
     "istanbul": "~0.4.0",
     "jshint": "~2.8.0",


### PR DESCRIPTION
Fixes #19.  Doesn't provide any further options, but useful for cross-platform npm scripts.