### PR TITLE
Change behavior of single file copy to imitate cp -R

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -304,7 +304,7 @@ var cpr = function(from, to, opts, callback) {
             }
         } else {
             if (stat.isFile()) {
-                return copyFile(options.from, path.join(to, path.basename(options.from)), options, callback);
+                return copyFile(options.from, to, options, callback);
             }
             callback(new Error('From should be a file or directory'));
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,7 +217,7 @@ var confirm = function(files, options, callback) {
             });
         }
     }
-    
+
     /*istanbul ignore else - filtered should be an array, but just in case*/
     if (filtered.length) {
         filtered.forEach(function(file) {
@@ -304,6 +304,10 @@ var cpr = function(from, to, opts, callback) {
             }
         } else {
             if (stat.isFile()) {
+                var dirRegex = new RegExp(path.sep + '$');
+                if (dirRegex.test(to)) { // Create directory if has trailing separator
+                  to = path.join(to, path.basename(options.from));
+                }
                 return copyFile(options.from, to, options, callback);
             }
             callback(new Error('From should be a file or directory'));

--- a/tests/full.js
+++ b/tests/full.js
@@ -349,16 +349,16 @@ describe('cpr test suite', function() {
         });
     
         it('should copy one file', function(done) {
-            cpr(__filename, path.join(to, 'one-file-test/'), { overwrite: true }, function(err) {
+            cpr(__filename, path.join(to, 'one-file-test.js'), { overwrite: true }, function(err) {
                 assert.equal(undefined, err);
-                var stat = fs.statSync(path.join(to, 'one-file-test/full.js'));
+                var stat = fs.statSync(path.join(to, 'one-file-test.js'));
                 assert.ok(stat.isFile());
                 done();
             });
         });
 
         it('should not copy because file exists', function(done) {
-            cpr(__filename, path.join(to, 'one-file-test/'), function(err, status) {
+            cpr(__filename, path.join(to, 'one-file-test.js'), function(err, status) {
                 assert.equal(undefined, status);
                 assert(err instanceof Error);
                 assert.ok(/^File .* exists$/.test(err.message));

--- a/tests/full.js
+++ b/tests/full.js
@@ -10,25 +10,25 @@ var assert = require('assert'),
 
 describe('cpr test suite', function() {
     this.timeout(55000);
-    
+
     describe('loading', function() {
         before(function() {
             rimraf.sync(to);
         });
-        
+
         it('should export raw method', function () {
             assert.equal(typeof cpr, 'function');
         });
-        
+
         it('should export cpr method too', function () {
             assert.equal(typeof cpr.cpr, 'function');
         });
     });
-    
+
     describe('should copy node_modules', function() {
         var out = path.join(to, '0');
         var data = {};
-        
+
         before(function(done) {
             cpr(from, out, function(err, status) {
                 data = {
@@ -38,7 +38,7 @@ describe('cpr test suite', function() {
                 done();
             });
         });
-            
+
         it('has ./out/0', function() {
             var stat = fs.statSync(out);
             assert.ok(stat.isDirectory());
@@ -63,7 +63,7 @@ describe('cpr test suite', function() {
         });
 
     });
-    
+
     describe('should NOT copy node_modules', function() {
         var out = path.join(to, '1'),
             data;
@@ -81,7 +81,7 @@ describe('cpr test suite', function() {
                 });
             });
         });
-        
+
         it('does not have ./out/1', function() {
             assert.ok(data.stat); // Should be an error
         });
@@ -89,7 +89,7 @@ describe('cpr test suite', function() {
             assert(data.err instanceof Error); // Should be an error
             assert.equal(data.err.message, 'No files to copy');
         });
-    
+
     });
 
     describe('should not copy yui-lint from regex', function() {
@@ -112,7 +112,7 @@ describe('cpr test suite', function() {
                 done();
             });
         });
-        
+
         it('returns files array with confirm', function() {
             assert.ok(Array.isArray(data.status));
             assert.ok(data.status.length > 0);
@@ -180,7 +180,7 @@ describe('cpr test suite', function() {
             });
             assert.equal(false, toHas);
         });
-    
+
     });
 
     describe('should copy minimatch from bad filter', function() {
@@ -222,7 +222,7 @@ describe('cpr test suite', function() {
             });
             assert.equal(true, toHasGFS);
         });
-    
+
     });
 
     describe('should copy node_modules with overwrite flag', function() {
@@ -270,11 +270,11 @@ describe('cpr test suite', function() {
             });
             assert.equal(true, toHasGFS);
         });
-    
+
     });
 
     describe('error handling', function() {
-    
+
         it('should fail on non-existant from dir', function(done) {
             cpr('./does/not/exist', path.join(to, 'does/not/matter'), function(err, status) {
                 assert.equal(undefined, status);
@@ -283,7 +283,7 @@ describe('cpr test suite', function() {
                 done();
             });
         });
-    
+
         it('should fail on non-file', function(done) {
             cpr('/dev/null', path.join(to, 'does/not/matter'), function(err, status) {
                 assert.equal(undefined, status);
@@ -325,7 +325,7 @@ describe('cpr test suite', function() {
     });
 
     describe('validations', function() {
-    
+
         it('should copy empty directory', function(done) {
             mkdirp.sync(path.join(to, 'empty-src'));
             cpr(path.join(to, 'empty-src'), path.join(to, 'empty-dest'), function() {
@@ -334,7 +334,7 @@ describe('cpr test suite', function() {
                 done();
             });
         });
-    
+
         it('should not delete existing folders in out dir', function(done) {
             mkdirp.sync(path.join(to, 'empty-src', 'a'));
             mkdirp.sync(path.join(to, 'empty-dest', 'b'));
@@ -347,11 +347,20 @@ describe('cpr test suite', function() {
                 done();
             });
         });
-    
+
         it('should copy one file', function(done) {
             cpr(__filename, path.join(to, 'one-file-test.js'), { overwrite: true }, function(err) {
                 assert.equal(undefined, err);
                 var stat = fs.statSync(path.join(to, 'one-file-test.js'));
+                assert.ok(stat.isFile());
+                done();
+            });
+        });
+
+        it('should copy one file in dir if to has trailing sep', function(done) {
+            cpr(__filename, path.join(to, 'one-file-dir'+path.sep), { overwrite: true }, function(err) {
+                assert.equal(undefined, err);
+                var stat = fs.statSync(path.join(to, 'one-file-dir','full.js'));
                 assert.ok(stat.isFile());
                 done();
             });
@@ -383,7 +392,7 @@ describe('cpr test suite', function() {
               done();
             });
         });
-        
+
         it('has ./out/4', function() {
             var stat = fs.statSync(out);
             assert.ok(stat.isDirectory());
@@ -403,7 +412,7 @@ describe('cpr test suite', function() {
             });
             assert.equal(true, toHasGFS);
         });
-    
+
     });
 
 });


### PR DESCRIPTION
When running `cp -R` in command line on a single file, the source file gets copied at the target path, the last bit of the path becoming the new file name unless there is a trailing `/`.

For example, starting with this structure:
```
foo/
 `-- bar.jpg
baz/
```
`cp -R foo/bar.jpg baz/qux.jpg` results in:
```
foo/
 `-- bar.jpg
baz/
 `-- qux.jpg
```
but `cp -R foo/bar.jpg baz/qux/` results in:
```
foo/
 `-- bar.jpg
baz/
 `-- qux/
      `-- bar.jpg
```

This pull request recreates this behavior and fixes #28.