### PR TITLE
Add simplified version of `filter` functionality to CLI

### DIFF
--- a/bin/cpr
+++ b/bin/cpr
@@ -5,7 +5,7 @@ var fs = require('fs');
 var minimist = require('minimist');
 
 var argv = minimist(process.argv.slice(2), {
-    alias: { d:'delete-first', h:'help', o:'overwrite', v:'version' }
+    alias: { d:'delete-first', f:'filter', h:'help', o:'overwrite', v:'version' }
 });
 
 if (argv.v) {
@@ -18,8 +18,15 @@ if (argv.h) {
     return;
 }
 
+var filter;
+
+if (argv.f) {
+    filter = new RegExp(argv.f, 'i');
+}
+
 cpr(argv._[0], argv._[1], {
     deleteFirst: argv.d,
+    filter: filter,
     overwrite: argv.o
 }, function (err) {
     if (err) {


### PR DESCRIPTION
This change allows you to use the filtering option through the CLI, with the simplifying assumption that the filter will be a case-insensitive regex.

I wanted this functionality so I could filter out things like the `.git` directory using the CLI wrapper and thought it would be worth sharing.