### PR TITLE
Preserve file mode of newly-created files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,9 @@ var copyFile = function(from, to, options, callback) {
             }
 
             var fromFile = fs.createReadStream(from),
-                toFile = fs.createWriteStream(to),
+                toFile = fs.createWriteStream(to, {
+                    mode: options.stats[from].mode
+                }),
                 err,
                 called = false,
                 cb = function(e) {
@@ -308,6 +310,9 @@ var cpr = function(from, to, opts, callback) {
                 if (dirRegex.test(to)) { // Create directory if has trailing separator
                   to = path.join(to, path.basename(options.from));
                 }
+                // ensure copyFile() can access cached stat
+                options.stats = options.stats || {};
+                options.stats[from] = stat;
                 return copyFile(options.from, to, options, callback);
             }
             callback(new Error('From should be a file or directory'));

--- a/tests/full.js
+++ b/tests/full.js
@@ -62,6 +62,10 @@ describe('cpr test suite', function() {
             assert.equal(true, toHasGFS);
         });
 
+        it('preserves file mode of copied files', function () {
+            var stat = fs.statSync(path.join(out, '.bin/mocha'));
+            assert.equal('755', (stat.mode & 0o777).toString(8));
+        });
     });
 
     describe('should NOT copy node_modules', function() {


### PR DESCRIPTION
I was copying a bunch of fixtures into a temp directory one day, and then I kept getting weird return codes (`error code 126` wat) when I tried to call executable files in those copied fixtures. I found out that the copied files were no longer `0777`, but `0666` (the default mask for files).

Sacré bleu!

Turns out [`fs.createWriteStream()`](https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_createwritestream_path_options) has a `mode` option that we should probably use.

Related to #34, but not a complete solution.