### PR TITLE
Allow don't use callback.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,6 +246,8 @@ var cpr = function(from, to, opts, callback) {
         opts = {};
     }
 
+    callback = typeof callback === 'function' ? callback : function () {};
+
     var options = {},
         proc;
 


### PR DESCRIPTION
It will trigger an Error if we calling cpr without offer a callback function. Sometimes we don't want to do something after cpr.