### PR TITLE
Fixing write race condition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,7 +169,7 @@ var copyFile = function(from, to, options, callback) {
 
             fromFile.on('error', onError);
             toFile.on('error', onError);
-            fromFile.once('end', function() {
+            toFile.once('finish', function() {
                 cb(err);
             });
             fromFile.pipe(toFile);


### PR DESCRIPTION
Fixing a race condition that can occur when copying files. Previously the finished callback was called when the file read stream was done reading, but potentially before the write stream was done.